### PR TITLE
Implement the privacy API

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -1,0 +1,48 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Defines {@link \availability_mobileapp\privacy\provider} class.
+ *
+ * @package     availability_mobileapp
+ * @category    privacy
+ * @copyright   2018 Sara Arjona <sara@moodle.com>
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace availability_mobileapp\privacy;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Privacy API implementation for the Restriction by Mobile app access plugin.
+ *
+ * @copyright  2018 Sara Arjona <sara@moodle.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class provider implements \core_privacy\local\metadata\null_provider {
+
+    use \core_privacy\local\legacy_polyfill;
+
+    /**
+     * Returns stringid of a text explaining that this plugin stores no personal data.
+     *
+     * @return string
+     */
+    public static function _get_reason() {
+        return 'privacy:metadata';
+    }
+}

--- a/lang/en/availability_mobileapp.php
+++ b/lang/en/availability_mobileapp.php
@@ -25,6 +25,7 @@
 $string['description'] = 'Require students to access (or not access) using the Mobile app.';
 $string['pluginname'] = 'Restriction by Mobile app access';
 $string['label_access'] = 'Type of access:';
+$string['privacy:metadata'] = 'Restriction by Mobile app access does not store any personal data';
 $string['requires_app'] = 'Access using the Mobile app';
 $string['requires_notapp'] = 'Access NOT using the Mobile app';
 $string['title'] = 'Mobile app';


### PR DESCRIPTION
We use this plugin on Moodle community sites. In order to have them GDPR compliant, we need all plugins having the privacy API implemented and I've been working on this one. Thanks in advance for merging it.

For the record, this is the recipe for the [plugin skeleton generator](https://moodle.org/plugins/tool_pluginskel) that prepared scaffolding for the patch:

```
name: Restriction by Mobile app access
component: availability_mobileapp
copyright: 2018 Sara Arjona <sara@moodle.com>

privacy:
  haspersonaldata: false
  uselegacypolyfill: true

```