### PR TITLE
Fix-8: Updated Declaration of availability_mobileapp_condition_testcase::setUp

### DIFF
--- a/tests/condition_test.php
+++ b/tests/condition_test.php
@@ -35,13 +35,13 @@ global $CFG;
  * @copyright availability_mobileapp
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class availability_mobileapp_condition_testcase extends advanced_testcase {
+class availability_mobileapp_condition_testcase extends \advanced_testcase {
     /**
      * Load required classes.
      */
-    public function setUp() {
+    protected function setUp(): void {
         // Load the mock info class so that it can be used.
-        global $CFG, $DB;
+        global $CFG;
         require_once($CFG->dirroot . '/availability/tests/fixtures/mock_info.php');
     }
 


### PR DESCRIPTION
This fix addresses the issue described in #8 , making the availability_mobileapp plugin's PHPUnit tests compatible with Moodle 3.10 and 3.11.

IMPORTANT NOTE: The declaration of setUp() becomes incompatible with versions of Moodle previous to 3.10. I would therefore recommend that this NOT be merged but rather that a new MOODLE_310_STABLE branch be created.

Best regards,

Michael Milette
