### PR TITLE
guard against passing NULL to strpos().

### DIFF
--- a/classes/condition.php
+++ b/classes/condition.php
@@ -94,7 +94,7 @@ class condition extends \core_availability\condition {
         }
 
         // Check rare cases, like webservice/pluginfile.php.
-        if (strpos($ME, "webservice/") !== false) {
+        if (!is_null($ME) && strpos($ME, "webservice/") !== false) {
             $token = optional_param('token', '', PARAM_ALPHANUM);
             if ($token) {
                 return true;


### PR DESCRIPTION
passing NULL as first arg to strpos() is deprecated as of PHP 8.1.

fixes #13 